### PR TITLE
Remove name parameter from Active Effect Events behavior

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -161,13 +161,6 @@ export class BaseEffectEventsRegionBehaviorType extends RegionBehaviorType {
     });
   }
 
-  static validateJoint(data) {
-    if (this.UUID_ACTIONS.includes(data.action) && !data.uuid)
-      throw new Error(`The uuid field is required for the ${data.action} action`);
-    if (this.NAME_ACTIONS.includes(data.action) && !data.name)
-      throw new Error(`The name field is required for the ${data.action} action`);
-  }
-
   async _handleRegionEvent(event) {
     // quick data verification
     const actor = event.data?.token?.actor;

--- a/src/base.js
+++ b/src/base.js
@@ -141,8 +141,6 @@ export class BaseEffectEventsRegionBehaviorType extends RegionBehaviorType {
   static LOCALIZATION_PREFIXES = ["RAE.TYPES.activeEffect", "RAE.TYPES.activeEffectEvents"];
 
   static ALL_ACTIONS = ["add", "resetDuration", "enable", "disable", "delete"];
-  static UUID_ACTIONS = ["add", "resetDuration"];
-  static NAME_ACTIONS = ["enable", "disable", "delete"];
 
   static _createEventsField() {
     return super._createEventsField({ events: TOKEN_EVENTS });

--- a/src/core.js
+++ b/src/core.js
@@ -142,20 +142,15 @@ function ActiveEffectMixin(Base) {
     }
 
     async _enableOrDisable(actor, disabled) {
-      const existingEffect = actor.effects.getName(this.name);
+      const effect = await fromUuid(this.uuid);
+      const existingEffect = actor.effects.getName(effect.name);
       if (existingEffect) return existingEffect.update({ disabled });
     }
 
     async _deleteEffect(actor) {
-      // find name
-      let name = this.name;
-      if (!name && this.uuid) {
-        const effect = await fromUuid(this.uuid);
-        name = effect.name;
-      }
-      // get effect and delete it
-      const existingEffect = actor.effects.getName(name);
-      if (existingEffect) await existingEffect.delete();
+      const effect = await fromUuid(this.uuid);
+      const existingEffect = actor.effects.getName(effect.name);
+      if (existingEffect) return existingEffect.delete();
     }
   };
 }
@@ -182,8 +177,7 @@ class ActiveEffectEventsRegionBehaviorType extends ActiveEffectMixin(
     return {
       events: this._createEventsField(),
       action: this._createActionField(),
-      uuid: new DocumentUUIDField({ type: "ActiveEffect" }),
-      name: new StringField({ required: false, blank: false, nullable: false }),
+      uuid: new DocumentUUIDField({ type: "ActiveEffect" })
     };
   }
 }

--- a/src/core.js
+++ b/src/core.js
@@ -34,16 +34,8 @@ export function init() {
         "region-active-effects.statusEffect",
         "region-active-effects.statusEffectEvents",
         "region-active-effects.activeEffect",
+        "region-active-effects.activeEffectEvents",
       ],
-      makeDefault: true,
-    }
-  );
-  DocumentSheetConfig.registerSheet(
-    RegionBehavior,
-    "region-active-effects",
-    ActiveEffectEventsRegionBehaviorConfig,
-    {
-      types: ["region-active-effects.activeEffectEvents"],
       makeDefault: true,
     }
   );
@@ -177,50 +169,7 @@ class ActiveEffectEventsRegionBehaviorType extends ActiveEffectMixin(
     return {
       events: this._createEventsField(),
       action: this._createActionField(),
-      uuid: new DocumentUUIDField({ type: "ActiveEffect" })
+      uuid: new DocumentUUIDField({ type: "ActiveEffect" }),
     };
-  }
-}
-
-/**
- * A custom sheet that hides/shows the uuid and name fields based on the action.
- */
-class ActiveEffectEventsRegionBehaviorConfig extends foundry.applications.sheets
-  .RegionBehaviorConfig {
-  _attachPartListeners(partId, htmlElement, options) {
-    super._attachPartListeners(partId, htmlElement, options);
-
-    if (partId === "form") {
-      // Add change listener to action to hide/show other fields
-      const action = htmlElement.querySelector("select[name='system.action']");
-      action.addEventListener("change", this.#onActionChange.bind(this));
-      // Set initial state of those fields
-      this.#toggleVisibility(action);
-    }
-  }
-
-  #onActionChange(event) {
-    const target = event.target;
-    this.#toggleVisibility(target);
-  }
-
-  #toggleVisibility(actionInput) {
-    const fieldset = actionInput.closest("fieldset");
-    const action = actionInput.value;
-
-    let showUuid,
-      showName = false;
-    if (ActiveEffectEventsRegionBehaviorType.UUID_ACTIONS.includes(action)) showUuid = true;
-    else if (ActiveEffectEventsRegionBehaviorType.NAME_ACTIONS.includes(action)) showName = true;
-
-    const uuid = fieldset.querySelector("div.form-group:has([name='system.uuid'])");
-    const name = fieldset.querySelector("div.form-group:has([name='system.name'])");
-
-    function change(element, show) {
-      if (show) element.classList.remove("hidden");
-      else element.classList.add("hidden");
-    }
-    change(uuid, showUuid);
-    change(name, showName);
   }
 }


### PR DESCRIPTION
After making the PF2e-specific Effect Events behavior, which didn't use a `name` parameter but just the `uuid` for all actions, it made the `name` parameter on the core Active Effects Events behavior seem redundant. This removes the `name` parameter and just expects the UUID all the time. Also removes the need for the custom sheet that hided/showed the uuid/name based on the action chosen.